### PR TITLE
Fixed a bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ loudness.getMuted(function (err, mute) {
 
 ## OS Support
 
-Currently Mac OS X and Linux (ALSA) is supported, please send a pull requests if you are using another setup.
+Currently Mac OS X and Linux (ALSA) is supported, please send a pull request if you are using another setup.

--- a/impl/linux.js
+++ b/impl/linux.js
@@ -101,7 +101,7 @@ module.exports.getMuted = function (cb) {
 };
 
 module.exports.setMuted = function (val, cb) {
-  amixer(['set', 'PCM', (val?'mute':'unmute')], function (err) {
+  amixer(['set', '-D', 'pulse', 'Master', (val?'mute':'unmute')], function (err) {
     cb(err);
   });
 };


### PR DESCRIPTION
- Fixed the bug **unmute not working**
- The module is still failing the test for `getVolume()` because the alsa mixer sets the volume at 1% more than the actual volume set.