### PR TITLE
Update darwin.js for latest Execa API

### DIFF
--- a/impl/darwin.js
+++ b/impl/darwin.js
@@ -1,7 +1,7 @@
 const execa = require('execa')
 
 function osascript (cmd) {
-  return execa.stdout('osascript', ['-e', cmd], { preferLocal: false })
+  return execa.sync('osascript', ['-e', cmd], { preferLocal: false }).stdout
 }
 
 exports.getVolume = function () {


### PR DESCRIPTION
Fixes "execa.stdout is not a function"