### PR TITLE
fix: 🐛 win path in asar

### DIFF
--- a/impl/windows/index.js
+++ b/impl/windows/index.js
@@ -1,10 +1,11 @@
 const execa = require('execa')
 const path = require('path')
+const utils = require('../../utils')
 
 const executablePath = path.join(__dirname, 'adjust_get_current_system_volume_vista_plus.exe')
 
 async function runProgram (...args) {
-  return (await execa(executablePath, args)).stdout
+  return (await execa(utils.fixWinAsarPath(executablePath), args)).stdout
 }
 
 async function getVolumeInfo () {

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,2 @@
+// fix: https://github.com/LinusU/node-loudness/issues/26
+exports.fixWinAsarPath = (url) => url.replace(/\\app\.asar\\/, '\\app.asar.unpacked\\')


### PR DESCRIPTION
fix: https://github.com/LinusU/node-loudness/issues/26