### PR TITLE
Allow to use Loudness on FreeBSD by reuse Linux implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ switch (os.type()) {
   case 'Darwin':
     impl = require('./impl/darwin')
     break
+  case 'FreeBSD':
+    impl = require('./impl/linux')
+    break
   case 'Linux':
     impl = require('./impl/linux')
     break


### PR DESCRIPTION
FreeBSD can reuse Linux implementation to handle alsa-mixer

Sponsored by:	Future Crew, LLC